### PR TITLE
pytest-cov with usage and configuration

### DIFF
--- a/docs/setup/pytest-cov.rst
+++ b/docs/setup/pytest-cov.rst
@@ -1,0 +1,85 @@
+=====================
+Testing: pytest-cov
+=====================
+
+**pytest-cov** is a powerful `pytest` plugin that integrates seamlessly with `coverage.py`
+to generate test coverage reports. It provides:
+
+- **Subprocess support** – Tracks coverage across subprocesses automatically.
+- **Better `pytest` integration** – Prevents issues like path mismatches with `coverage run -m pytest`.
+- **Full support for coverage configuration and reporting**.
+
+All functionality from the `coverage` package is supported and can be customized via
+command-line flags or `pyproject.toml`.
+
+📚 For complete reference, visit the
+`official docs <https://pytest-cov.readthedocs.io/en/latest/readme.html>`_.
+
+Installation
+============
+
+Install as a development dependency using `uv`:
+
+.. code-block:: console
+
+    $ uv add --dev pytest-cov
+
+.. note::
+
+    You can replace both ``pytest`` and ``coverage`` with ``pytest-cov`` in your
+    development dependencies for a simpler and more unified setup.
+
+Usage
+=====
+
+Basic usage to collect coverage:
+
+.. code-block:: console
+
+    $ pytest --cov
+
+Show missing lines directly in terminal output:
+
+.. code-block:: console
+
+    $ pytest --cov --cov-report=term-missing
+
+Skip fully covered files from the terminal report:
+
+.. code-block:: console
+
+    $ pytest --cov --cov-report=term-missing:skip-covered
+
+Generate an HTML report with annotated source files:
+
+.. code-block:: console
+
+    $ pytest --cov --cov-report=html
+    $ brave-browser htmlcov/index.html
+
+.. note::
+
+    The HTML report will be saved in the ``htmlcov/`` directory. You can open it using
+    your preferred web browser.
+
+Configuration
+=============
+
+To apply coverage options automatically for all test runs, configure `pytest` via `pyproject.toml`:
+
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    testpaths = ["tests"]
+    addopts = "--cov --cov-report=term-missing"
+
+This ensures that all test executions include coverage reporting by default.
+
+Uninstallation
+==============
+
+To remove `pytest-cov` from your environment:
+
+.. code-block:: console
+
+    $ uv remove --dev pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
   "mypy>=1.16.1",
   "pre-commit>=4.2.0",
   "pytest>=8.4.0",
+  "pytest-cov>=6.2.1",
   "ruff>=0.11.13",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ homepage = "https://github.com/ghimiresunil/PyFoundry.git"
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = ["tests"]
+addopts = "--cov --cov-report=term-missing"
 
 [tool.coverage.run]
 branch = true

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -242,6 +243,7 @@ dev = [
     { name = "mypy", specifier = ">=1.16.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 
@@ -268,6 +270,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Overview of pytest-cov features and benefits
- Installation instructions using uv
- Command-line usage examples:
--cov
--cov-report=term-missing
--cov-report=html
--cov-report=term-missing:skip-covered
- Configuration guidance via pyproject.toml to enable coverage by default
- Additional note on simplifying dev dependencies by replacing pytest and coverage with pytest-cov


